### PR TITLE
Build fixes

### DIFF
--- a/aes2r.c
+++ b/aes2r.c
@@ -186,16 +186,16 @@ void aes2r_encrypt(uint8_t * state, uint8_t * key) {
 
 #else
     /* first round of the algorithm */
-    add_round_key(state, (void*)&key_schedule[0]);
+    add_round_key(state, (uint8_t*)&key_schedule[0]);
     sub_bytes(state);
     shift_rows(state);
     mix_columns(state);
-    add_round_key(state, (void*)&key_schedule[4]);
+    add_round_key(state, (uint8_t*)&key_schedule[4]);
 
     /* final round of the algorithm */
     sub_bytes(state);
     shift_rows(state);
-    add_round_key(state, (void*)&key_schedule[8]);
+    add_round_key(state, (uint8_t*)&key_schedule[8]);
 
 #endif
 }

--- a/patches/cpuminer-multi-134-rf256.diff
+++ b/patches/cpuminer-multi-134-rf256.diff
@@ -1,15 +1,21 @@
-commit 0098492787dea4888c4fa179a16d0c74a2055e2b
-Author: Mike Murdock <42321661+MikeMurdo@users.noreply.github.com>
-Date:   Sun Aug 12 19:32:18 2018 +0200
-
-    add rainforest algo
-
+diff --git a/Makefile.am b/Makefile.am
+index 8ce8715..0d389dd 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -85,6 +85,7 @@ cpuminer_SOURCES = \
+   algo/nist5.c \
+   algo/pluck.c \
+   algo/qubit.c \
++  algo/rainforest.c \
+   algo/scrypt.c \
+   algo/scrypt-jane.c \
+   algo/sha2.c \
 diff --git a/algo/rainforest.c b/algo/rainforest.c
 new file mode 100644
-index 0000000..4a36346
+index 0000000..c5a17cd
 --- /dev/null
 +++ b/algo/rainforest.c
-@@ -0,0 +1,855 @@
+@@ -0,0 +1,857 @@
 +// RainForest hash algorithm
 +// Author: Bill Schneider
 +// Date: Feb 13th, 2018
@@ -225,16 +231,16 @@ index 0000000..4a36346
 +
 +#else
 +    /* first round of the algorithm */
-+    add_round_key(state, (void*)&key_schedule[0]);
++    add_round_key(state, (uint8_t*)&key_schedule[0]);
 +    sub_bytes(state);
 +    shift_rows(state);
 +    mix_columns(state);
-+    add_round_key(state, (void*)&key_schedule[4]);
++    add_round_key(state, (uint8_t*)&key_schedule[4]);
 +
 +    /* final round of the algorithm */
 +    sub_bytes(state);
 +    shift_rows(state);
-+    add_round_key(state, (void*)&key_schedule[8]);
++    add_round_key(state, (uint8_t*)&key_schedule[8]);
 +
 +#endif
 +}
@@ -551,7 +557,7 @@ index 0000000..4a36346
 +}
 +
 +// write (_x_,_y_) at cell _cell_ for offset _ofs_
-+static inline void rf_w128(uint64_t *cell, ulong ofs, uint64_t x, uint64_t y) {
++static inline void rf_w128(uint64_t *cell, size_t ofs, uint64_t x, uint64_t y) {
 +#if defined(__ARM_ARCH_8A) || defined(__AARCH64EL__)
 +  // 128 bit at once is faster when exactly two parallelizable instructions are
 +  // used between two calls to keep the pipe full.
@@ -768,18 +774,20 @@ index 0000000..4a36346
 +
 +// update the hash context _ctx_ with _len_ bytes from message _msg_
 +static void rf256_update(rf256_ctx_t *ctx, const void *msg, size_t len) {
++  const uint8_t *msg8 = (uint8_t *)msg;
++
 +  while (len > 0) {
 +#ifdef RF_UNALIGNED_LE32
 +    if (!(ctx->len&3) && len>=4) {
-+      ctx->word=*(uint32_t *)msg;
++      ctx->word=*(uint32_t *)msg8;
 +      ctx->len+=4;
 +      rf256_one_round(ctx);
-+      msg+=4;
++      msg8+=4;
 +      len-=4;
 +      continue;
 +    }
 +#endif
-+    ctx->word|=((uint32_t)*(uint8_t *)msg++)<<(8*(ctx->len++&3));
++    ctx->word|=((uint32_t)*msg++)<<(8*(ctx->len++&3));
 +    len--;
 +    if (!(ctx->len&3))
 +      rf256_one_round(ctx);
@@ -865,3 +873,53 @@ index 0000000..4a36346
 +	*hashes_done = pdata[19] - first_nonce + 1;
 +	return 0;
 +}
+diff --git a/cpu-miner.c b/cpu-miner.c
+index 7bdc175..8c538e9 100644
+--- a/cpu-miner.c
++++ b/cpu-miner.c
+@@ -109,6 +109,7 @@ enum algos {
+ 	ALGO_PHI2,
+ 	ALGO_PLUCK,       /* Pluck (Supcoin) */
+ 	ALGO_QUBIT,       /* Qubit */
++	ALGO_RAINFOREST,  /* RainForest */
+ 	ALGO_SCRYPT,      /* scrypt */
+ 	ALGO_SCRYPTJANE,  /* Chacha */
+ 	ALGO_SHAVITE3,    /* Shavite3 */
+@@ -172,6 +173,7 @@ static const char *algo_names[] = {
+ 	"phi2",
+ 	"pluck",
+ 	"qubit",
++	"rainforest",
+ 	"scrypt",
+ 	"scrypt-jane",
+ 	"shavite3",
+@@ -334,6 +336,7 @@ Options:\n\
+                           phi2         LUX newer algo\n\
+                           quark        Quark\n\
+                           qubit        Qubit\n\
++                          rainforest   RainForest (256)\n\
+                           scrypt       scrypt(1024, 1, 1) (default)\n\
+                           scrypt:N     scrypt(N, 1, 1)\n\
+                           scrypt-jane:N (with N factor from 4 to 30)\n\
+@@ -2332,6 +2335,9 @@ static void *miner_thread(void *userdata)
+ 		case ALGO_QUBIT:
+ 			rc = scanhash_qubit(thr_id, &work, max_nonce, &hashes_done);
+ 			break;
++		case ALGO_RAINFOREST:
++			rc = scanhash_rf256(thr_id, &work, max_nonce, &hashes_done);
++			break;
+ 		case ALGO_SCRYPT:
+ 			rc = scanhash_scrypt(thr_id, &work, max_nonce, &hashes_done, scratchbuf, opt_scrypt_n);
+ 			break;
+diff --git a/miner.h b/miner.h
+index 8a6aec2..9ecbb88 100644
+--- a/miner.h
++++ b/miner.h
+@@ -231,6 +231,7 @@ int scanhash_pluck(int thr_id, struct work *work, uint32_t max_nonce, uint64_t *
+ int scanhash_quark(int thr_id, struct work *work, uint32_t max_nonce, uint64_t *hashes_done);
+ void init_quarkhash_contexts();
+ int scanhash_qubit(int thr_id, struct work *work, uint32_t max_nonce, uint64_t *hashes_done);
++int scanhash_rf256(int thr_id, struct work *work, uint32_t max_nonce, uint64_t *hashes_done);
+ int scanhash_sha256d(int thr_id, struct work *work, uint32_t max_nonce, uint64_t *hashes_done);
+ unsigned char *scrypt_buffer_alloc(int N);
+ int scanhash_scrypt(int thr_id, struct work *work, uint32_t max_nonce, uint64_t *hashes_done,

--- a/patches/sgminer-gm-add-rainforest+precalc.diff
+++ b/patches/sgminer-gm-add-rainforest+precalc.diff
@@ -1,9 +1,3 @@
-commit 0fe72601a43397a6df2ab2abfcabfa7ea5a65a2a
-Author: Mike Murdock <42321661+MikeMurdo@users.noreply.github.com>
-Date:   Sun Aug 12 19:37:39 2018 +0200
-
-    add rainforest algo
-
 diff --git a/Makefile.am b/Makefile.am
 index 69922b3..44c3528 100644
 --- a/Makefile.am
@@ -120,10 +114,10 @@ index 54e2308..427da4a 100644
    ALGO_BLAKECOIN,
 diff --git a/algorithm/rainforest.c b/algorithm/rainforest.c
 new file mode 100644
-index 0000000..b65b67e
+index 0000000..d0cf25c
 --- /dev/null
 +++ b/algorithm/rainforest.c
-@@ -0,0 +1,806 @@
+@@ -0,0 +1,808 @@
 +#include "config.h"
 +#include "miner.h"
 +
@@ -305,16 +299,16 @@ index 0000000..b65b67e
 +
 +#else
 +    /* first round of the algorithm */
-+    add_round_key(state, (void*)&key_schedule[0]);
++    add_round_key(state, (uint8_t*)&key_schedule[0]);
 +    sub_bytes(state);
 +    shift_rows(state);
 +    mix_columns(state);
-+    add_round_key(state, (void*)&key_schedule[4]);
++    add_round_key(state, (uint8_t*)&key_schedule[4]);
 +
 +    /* final round of the algorithm */
 +    sub_bytes(state);
 +    shift_rows(state);
-+    add_round_key(state, (void*)&key_schedule[8]);
++    add_round_key(state, (uint8_t*)&key_schedule[8]);
 +
 +#endif
 +}
@@ -631,7 +625,7 @@ index 0000000..b65b67e
 +}
 +
 +// write (_x_,_y_) at cell _cell_ for offset _ofs_
-+static inline void rf_w128(uint64_t *cell, ulong ofs, uint64_t x, uint64_t y) {
++static inline void rf_w128(uint64_t *cell, size_t ofs, uint64_t x, uint64_t y) {
 +#if defined(__ARM_ARCH_8A) || defined(__AARCH64EL__)
 +  // 128 bit at once is faster when exactly two parallelizable instructions are
 +  // used between two calls to keep the pipe full.
@@ -848,18 +842,20 @@ index 0000000..b65b67e
 +
 +// update the hash context _ctx_ with _len_ bytes from message _msg_
 +static void rf256_update(rf256_ctx_t *ctx, const void *msg, size_t len) {
++  const uint8_t *msg8 = (uint8_t *)msg;
++
 +  while (len > 0) {
 +#ifdef RF_UNALIGNED_LE32
 +    if (!(ctx->len&3) && len>=4) {
-+      ctx->word=*(uint32_t *)msg;
++      ctx->word=*(uint32_t *)msg8;
 +      ctx->len+=4;
 +      rf256_one_round(ctx);
-+      msg+=4;
++      msg8+=4;
 +      len-=4;
 +      continue;
 +    }
 +#endif
-+    ctx->word|=((uint32_t)*(uint8_t *)msg++)<<(8*(ctx->len++&3));
++    ctx->word|=((uint32_t)*msg++)<<(8*(ctx->len++&3));
 +    len--;
 +    if (!(ctx->len&3))
 +      rf256_one_round(ctx);

--- a/rainforest.c
+++ b/rainforest.c
@@ -327,7 +327,7 @@ static inline uint32_t rf_rambox(uint64_t *rambox, uint64_t old) {
 }
 
 // write (_x_,_y_) at cell _cell_ for offset _ofs_
-static inline void rf_w128(uint64_t *cell, ulong ofs, uint64_t x, uint64_t y) {
+static inline void rf_w128(uint64_t *cell, size_t ofs, uint64_t x, uint64_t y) {
 #if defined(__ARM_ARCH_8A) || defined(__AARCH64EL__)
   // 128 bit at once is faster when exactly two parallelizable instructions are
   // used between two calls to keep the pipe full.

--- a/rainforest.c
+++ b/rainforest.c
@@ -542,18 +542,20 @@ void rf256_init(rf256_ctx_t *ctx) {
 
 // update the hash context _ctx_ with _len_ bytes from message _msg_
 void rf256_update(rf256_ctx_t *ctx, const void *msg, size_t len) {
+  const uint8_t *msg8 = (uint8_t *)msg;
+
   while (len > 0) {
 #ifdef RF_UNALIGNED_LE32
     if (!(ctx->len&3) && len>=4) {
-      ctx->word=*(uint32_t *)msg;
+      ctx->word=*(uint32_t *)msg8;
       ctx->len+=4;
       rf256_one_round(ctx);
-      msg+=4;
+      msg8+=4;
       len-=4;
       continue;
     }
 #endif
-    ctx->word|=((uint32_t)*(uint8_t *)msg++)<<(8*(ctx->len++&3));
+    ctx->word|=((uint32_t)*msg8++)<<(8*(ctx->len++&3));
     len--;
     if (!(ctx->len&3))
       rf256_one_round(ctx);


### PR DESCRIPTION
Hello Bill,
some users are facing build errors and warnings like here https://imgur.com/uEOLZpL or here https://gist.github.com/quagliero/90f493f123c7b1ddba5428ba0146329a#gistcomment-2800719 .

I've addressed them, they were missing types (ulong) and void* arithmetics (forbidden in C++). I have also updated the patches for cpuminer and sgminer. For yiimp I have not updated it as tpruvot merged it and fixed it already. But the cpuminer and sgminer patches are likely to be applied as is on forks from older versions of these miners.

Please merge this as adoption by some coins might possibly be stopped just because of this.