### PR TITLE
updates to fix windows build

### DIFF
--- a/aes2r.c
+++ b/aes2r.c
@@ -157,7 +157,7 @@ void aes2r_encrypt(uint8_t * state, uint8_t * key) {
 
 // Use -march=armv8-a+crypto+crc to get this one
 #if defined(__aarch64__) && defined(__ARM_FEATURE_CRYPTO)
-    asm volatile(
+    __asm__ volatile(
         "ld1   {v0.16b},[%0]        \n"
 	"ld1   {v1.16b,v2.16b,v3.16b},[%1]  \n"
 	"aese  v0.16b,v1.16b        \n" // round1: add_round_key,sub_bytes,shift_rows
@@ -171,7 +171,7 @@ void aes2r_encrypt(uint8_t * state, uint8_t * key) {
 
 // Use -maes to get this one
 #elif defined(__x86_64__) && defined(__AES__)
-    asm volatile(
+    __asm__ volatile(
         "movups (%0),  %%xmm0     \n"
 	"movups (%1),  %%xmm1     \n"
 	"pxor   %%xmm1,%%xmm0     \n" // add_round_key(state, key_schedule)

--- a/patches/cpuminer-multi-134-rf256.diff
+++ b/patches/cpuminer-multi-134-rf256.diff
@@ -202,7 +202,7 @@ index 0000000..c5a17cd
 +
 +// Use -march=armv8-a+crypto+crc to get this one
 +#if defined(__aarch64__) && defined(__ARM_FEATURE_CRYPTO)
-+    asm volatile(
++    __asm__ volatile(
 +        "ld1   {v0.16b},[%0]        \n"
 +	"ld1   {v1.16b,v2.16b,v3.16b},[%1]  \n"
 +	"aese  v0.16b,v1.16b        \n" // round1: add_round_key,sub_bytes,shift_rows
@@ -216,7 +216,7 @@ index 0000000..c5a17cd
 +
 +// Use -maes to get this one
 +#elif defined(__x86_64__) && defined(__AES__)
-+    asm volatile(
++    __asm__ volatile(
 +        "movups (%0),  %%xmm0     \n"
 +	"movups (%1),  %%xmm1     \n"
 +	"pxor   %%xmm1,%%xmm0     \n" // add_round_key(state, key_schedule)
@@ -410,7 +410,7 @@ index 0000000..c5a17cd
 +// build with -mcpu=cortex-a53+crc to enable native CRC instruction on ARM
 +static inline uint32_t rf_crc32_32(uint32_t crc, uint32_t msg) {
 +#if defined(__aarch64__) && defined(__ARM_FEATURE_CRC32)
-+  asm("crc32w %w0,%w0,%w1\n":"+r"(crc):"r"(msg));
++  __asm__("crc32w %w0,%w0,%w1\n":"+r"(crc):"r"(msg));
 +#else
 +  crc=crc^msg;
 +  crc=rf_crc32_table[crc&0xff]^(crc>>8);
@@ -423,8 +423,8 @@ index 0000000..c5a17cd
 +
 +//static inline uint32_t rf_crc32_24(uint32_t crc, uint32_t msg) {
 +//#if defined(__aarch64__) && defined(__ARM_FEATURE_CRC32)
-+//  asm("crc32b %w0,%w0,%w1\n":"+r"(crc):"r"(msg));
-+//  asm("crc32h %w0,%w0,%w1\n":"+r"(crc):"r"(msg>>8));
++//  __asm__("crc32b %w0,%w0,%w1\n":"+r"(crc):"r"(msg));
++//  __asm__("crc32h %w0,%w0,%w1\n":"+r"(crc):"r"(msg>>8));
 +//#else
 +//  crc=crc^msg;
 +//  crc=rf_crc32_table[crc&0xff]^(crc>>8);
@@ -436,7 +436,7 @@ index 0000000..c5a17cd
 +//
 +//static inline uint32_t rf_crc32_16(uint32_t crc, uint32_t msg) {
 +//#if defined(__aarch64__) && defined(__ARM_FEATURE_CRC32)
-+//  asm("crc32h %w0,%w0,%w1\n":"+r"(crc):"r"(msg));
++//  __asm__("crc32h %w0,%w0,%w1\n":"+r"(crc):"r"(msg));
 +//#else
 +//  crc=crc^msg;
 +//  crc=rf_crc32_table[crc&0xff]^(crc>>8);
@@ -447,7 +447,7 @@ index 0000000..c5a17cd
 +//
 +//static inline uint32_t rf_crc32_8(uint32_t crc, uint32_t msg) {
 +//#if defined(__aarch64__) && defined(__ARM_FEATURE_CRC32)
-+//  asm("crc32b %w0,%w0,%w1\n":"+r"(crc):"r"(msg));
++//  __asm__("crc32b %w0,%w0,%w1\n":"+r"(crc):"r"(msg));
 +//#else
 +//  crc=crc^msg;
 +//  crc=rf_crc32_table[crc&0xff]^(crc>>8);
@@ -460,7 +460,7 @@ index 0000000..c5a17cd
 +static inline uint64_t rf_add64_crc32(uint64_t msg) {
 +  uint64_t crc=0;
 +#if defined(__aarch64__) && defined(__ARM_FEATURE_CRC32)
-+  asm("crc32x %w0,%w0,%x1\n":"+r"(crc):"r"(msg));
++  __asm__("crc32x %w0,%w0,%x1\n":"+r"(crc):"r"(msg));
 +#else
 +  crc^=(uint32_t)msg;
 +  crc=rf_crc32_table[crc&0xff]^(crc>>8);
@@ -528,9 +528,9 @@ index 0000000..c5a17cd
 +// reverse all bytes in the word _v_
 +static inline uint64_t rf_bswap64(uint64_t v) {
 +#if defined(__x86_64__)
-+  asm("bswap %0":"+r"(v));
++  __asm__("bswap %0":"+r"(v));
 +#elif defined(__aarch64__)
-+  asm("rev %0,%0\n":"+r"(v));
++  __asm__("rev %0,%0\n":"+r"(v));
 +#else
 +  v=((v&0xff00ff00ff00ff00ULL)>>8)|((v&0x00ff00ff00ff00ffULL)<<8);
 +  v=((v&0xffff0000ffff0000ULL)>>16)|((v&0x0000ffff0000ffffULL)<<16);
@@ -561,7 +561,7 @@ index 0000000..c5a17cd
 +#if defined(__ARM_ARCH_8A) || defined(__AARCH64EL__)
 +  // 128 bit at once is faster when exactly two parallelizable instructions are
 +  // used between two calls to keep the pipe full.
-+  asm volatile("stp %0, %1, [%2,#%3]\n\t"
++  __asm__ volatile("stp %0, %1, [%2,#%3]\n\t"
 +               : /* no output */
 +               : "r"(x), "r"(y), "r" (cell), "I" (ofs*8));
 +#else

--- a/patches/sgminer-gm-add-rainforest+precalc.diff
+++ b/patches/sgminer-gm-add-rainforest+precalc.diff
@@ -270,7 +270,7 @@ index 0000000..d0cf25c
 +
 +// Use -march=armv8-a+crypto+crc to get this one
 +#if defined(__aarch64__) && defined(__ARM_FEATURE_CRYPTO)
-+    asm volatile(
++    __asm__ volatile(
 +        "ld1   {v0.16b},[%0]        \n"
 +	"ld1   {v1.16b,v2.16b,v3.16b},[%1]  \n"
 +	"aese  v0.16b,v1.16b        \n" // round1: add_round_key,sub_bytes,shift_rows
@@ -284,7 +284,7 @@ index 0000000..d0cf25c
 +
 +// Use -maes to get this one
 +#elif defined(__x86_64__) && defined(__AES__)
-+    asm volatile(
++    __asm__ volatile(
 +        "movups (%0),  %%xmm0     \n"
 +	"movups (%1),  %%xmm1     \n"
 +	"pxor   %%xmm1,%%xmm0     \n" // add_round_key(state, key_schedule)
@@ -478,7 +478,7 @@ index 0000000..d0cf25c
 +// build with -mcpu=cortex-a53+crc to enable native CRC instruction on ARM
 +static inline uint32_t rf_crc32_32(uint32_t crc, uint32_t msg) {
 +#if defined(__aarch64__) && defined(__ARM_FEATURE_CRC32)
-+  asm("crc32w %w0,%w0,%w1\n":"+r"(crc):"r"(msg));
++  __asm__("crc32w %w0,%w0,%w1\n":"+r"(crc):"r"(msg));
 +#else
 +  crc=crc^msg;
 +  crc=rf_crc32_table[crc&0xff]^(crc>>8);
@@ -491,8 +491,8 @@ index 0000000..d0cf25c
 +
 +//static inline uint32_t rf_crc32_24(uint32_t crc, uint32_t msg) {
 +//#if defined(__aarch64__) && defined(__ARM_FEATURE_CRC32)
-+//  asm("crc32b %w0,%w0,%w1\n":"+r"(crc):"r"(msg));
-+//  asm("crc32h %w0,%w0,%w1\n":"+r"(crc):"r"(msg>>8));
++//  __asm__("crc32b %w0,%w0,%w1\n":"+r"(crc):"r"(msg));
++//  __asm__("crc32h %w0,%w0,%w1\n":"+r"(crc):"r"(msg>>8));
 +//#else
 +//  crc=crc^msg;
 +//  crc=rf_crc32_table[crc&0xff]^(crc>>8);
@@ -504,7 +504,7 @@ index 0000000..d0cf25c
 +//
 +//static inline uint32_t rf_crc32_16(uint32_t crc, uint32_t msg) {
 +//#if defined(__aarch64__) && defined(__ARM_FEATURE_CRC32)
-+//  asm("crc32h %w0,%w0,%w1\n":"+r"(crc):"r"(msg));
++//  __asm__("crc32h %w0,%w0,%w1\n":"+r"(crc):"r"(msg));
 +//#else
 +//  crc=crc^msg;
 +//  crc=rf_crc32_table[crc&0xff]^(crc>>8);
@@ -515,7 +515,7 @@ index 0000000..d0cf25c
 +//
 +//static inline uint32_t rf_crc32_8(uint32_t crc, uint32_t msg) {
 +//#if defined(__aarch64__) && defined(__ARM_FEATURE_CRC32)
-+//  asm("crc32b %w0,%w0,%w1\n":"+r"(crc):"r"(msg));
++//  __asm__("crc32b %w0,%w0,%w1\n":"+r"(crc):"r"(msg));
 +//#else
 +//  crc=crc^msg;
 +//  crc=rf_crc32_table[crc&0xff]^(crc>>8);
@@ -528,7 +528,7 @@ index 0000000..d0cf25c
 +static inline uint64_t rf_add64_crc32(uint64_t msg) {
 +  uint64_t crc=0;
 +#if defined(__aarch64__) && defined(__ARM_FEATURE_CRC32)
-+  asm("crc32x %w0,%w0,%x1\n":"+r"(crc):"r"(msg));
++  __asm__("crc32x %w0,%w0,%x1\n":"+r"(crc):"r"(msg));
 +#else
 +  crc^=(uint32_t)msg;
 +  crc=rf_crc32_table[crc&0xff]^(crc>>8);
@@ -596,9 +596,9 @@ index 0000000..d0cf25c
 +// reverse all bytes in the word _v_
 +static inline uint64_t rf_bswap64(uint64_t v) {
 +#if defined(__x86_64__)
-+  asm("bswap %0":"+r"(v));
++  __asm__("bswap %0":"+r"(v));
 +#elif defined(__aarch64__)
-+  asm("rev %0,%0\n":"+r"(v));
++  __asm__("rev %0,%0\n":"+r"(v));
 +#else
 +  v=((v&0xff00ff00ff00ff00ULL)>>8)|((v&0x00ff00ff00ff00ffULL)<<8);
 +  v=((v&0xffff0000ffff0000ULL)>>16)|((v&0x0000ffff0000ffffULL)<<16);
@@ -629,7 +629,7 @@ index 0000000..d0cf25c
 +#if defined(__ARM_ARCH_8A) || defined(__AARCH64EL__)
 +  // 128 bit at once is faster when exactly two parallelizable instructions are
 +  // used between two calls to keep the pipe full.
-+  asm volatile("stp %0, %1, [%2,#%3]\n\t"
++  __asm__ volatile("stp %0, %1, [%2,#%3]\n\t"
 +               : /* no output */
 +               : "r"(x), "r"(y), "r" (cell), "I" (ofs*8));
 +#else

--- a/patches/smhasher-rf256.diff
+++ b/patches/smhasher-rf256.diff
@@ -227,7 +227,7 @@
 + 
 + // Use -march=armv8-a+crypto+crc to get this one
 + #if defined(__aarch64__) && defined(__ARM_FEATURE_CRYPTO)
-+     asm volatile(
++     __asm__ volatile(
 +         "ld1   {v0.16b},[%0]        \n"
 + 	"ld1   {v1.16b,v2.16b,v3.16b},[%1]  \n"
 + 	"aese  v0.16b,v1.16b        \n" // round1: add_round_key,sub_bytes,shift_rows
@@ -241,7 +241,7 @@
 + 
 + // Use -maes to get this one
 + #elif defined(__x86_64__) && defined(__AES__)
-+     asm volatile(
++     __asm__ volatile(
 +         "movups (%0),  %%xmm0     \n"
 + 	"movups (%1),  %%xmm1     \n"
 + 	"pxor   %%xmm1,%%xmm0     \n" // add_round_key(state, key_schedule)
@@ -1737,7 +1737,7 @@
 + // build with -mcpu=cortex-a53+crc to enable native CRC instruction on ARM
 + static inline uint32_t rf_crc32_32(uint32_t crc, uint32_t msg) {
 + #if defined(__aarch64__) && defined(__ARM_FEATURE_CRC32)
-+   asm("crc32w %w0,%w0,%w1\n":"+r"(crc):"r"(msg));
++   __asm__("crc32w %w0,%w0,%w1\n":"+r"(crc):"r"(msg));
 + #else
 +   crc=crc^msg;
 +   crc=rf_crc32_table[crc&0xff]^(crc>>8);
@@ -1750,8 +1750,8 @@
 + 
 + static inline uint32_t rf_crc32_24(uint32_t crc, uint32_t msg) {
 + #if defined(__aarch64__) && defined(__ARM_FEATURE_CRC32)
-+   asm("crc32b %w0,%w0,%w1\n":"+r"(crc):"r"(msg));
-+   asm("crc32h %w0,%w0,%w1\n":"+r"(crc):"r"(msg>>8));
++   __asm__("crc32b %w0,%w0,%w1\n":"+r"(crc):"r"(msg));
++   __asm__("crc32h %w0,%w0,%w1\n":"+r"(crc):"r"(msg>>8));
 + #else
 +   crc=crc^msg;
 +   crc=rf_crc32_table[crc&0xff]^(crc>>8);
@@ -1763,7 +1763,7 @@
 + 
 + static inline uint32_t rf_crc32_16(uint32_t crc, uint32_t msg) {
 + #if defined(__aarch64__) && defined(__ARM_FEATURE_CRC32)
-+   asm("crc32h %w0,%w0,%w1\n":"+r"(crc):"r"(msg));
++   __asm__("crc32h %w0,%w0,%w1\n":"+r"(crc):"r"(msg));
 + #else
 +   crc=crc^msg;
 +   crc=rf_crc32_table[crc&0xff]^(crc>>8);
@@ -1774,7 +1774,7 @@
 + 
 + static inline uint32_t rf_crc32_8(uint32_t crc, uint32_t msg) {
 + #if defined(__aarch64__) && defined(__ARM_FEATURE_CRC32)
-+   asm("crc32b %w0,%w0,%w1\n":"+r"(crc):"r"(msg));
++   __asm__("crc32b %w0,%w0,%w1\n":"+r"(crc):"r"(msg));
 + #else
 +   crc=crc^msg;
 +   crc=rf_crc32_table[crc&0xff]^(crc>>8);
@@ -1787,7 +1787,7 @@
 + static inline uint64_t rf_add64_crc32(uint64_t msg) {
 +   uint64_t crc=0;
 + #if defined(__aarch64__) && defined(__ARM_FEATURE_CRC32)
-+   asm("crc32x %w0,%w0,%x1\n":"+r"(crc):"r"(msg));
++   __asm__("crc32x %w0,%w0,%x1\n":"+r"(crc):"r"(msg));
 + #else
 +   crc^=(uint32_t)msg;
 +   crc=rf_crc32_table[crc&0xff]^(crc>>8);
@@ -1855,9 +1855,9 @@
 + // reverse all bytes in the word _v_
 + static inline uint64_t rf_bswap64(uint64_t v) {
 + #if defined(__x86_64__)
-+   asm("bswap %0":"+r"(v));
++   __asm__("bswap %0":"+r"(v));
 + #elif defined(__aarch64__)
-+   asm("rev %0,%0\n":"+r"(v));
++   __asm__("rev %0,%0\n":"+r"(v));
 + #else
 +   v=((v&0xff00ff00ff00ff00ULL)>>8)|((v&0x00ff00ff00ff00ffULL)<<8);
 +   v=((v&0xffff0000ffff0000ULL)>>16)|((v&0x0000ffff0000ffffULL)<<16);
@@ -1888,7 +1888,7 @@
 + #if defined(__ARM_ARCH_8A) || defined(__AARCH64EL__)
 +   // 128 bit at once is faster when exactly two parallelizable instructions are
 +   // used between two calls to keep the pipe full.
-+   asm volatile("stp %0, %1, [%2,#%3]\n\t"
++   __asm__ volatile("stp %0, %1, [%2,#%3]\n\t"
 +                : /* no output */
 +                : "r"(x), "r"(y), "r" (cell), "I" (ofs*8));
 + #else

--- a/patches/yiimp-rainforest.diff
+++ b/patches/yiimp-rainforest.diff
@@ -206,7 +206,7 @@
 + 
 + // Use -march=armv8-a+crypto+crc to get this one
 + #if defined(__aarch64__) && defined(__ARM_FEATURE_CRYPTO)
-+     asm volatile(
++     __asm__ volatile(
 +         "ld1   {v0.16b},[%0]        \n"
 + 	"ld1   {v1.16b,v2.16b,v3.16b},[%1]  \n"
 + 	"aese  v0.16b,v1.16b        \n" // round1: add_round_key,sub_bytes,shift_rows
@@ -220,7 +220,7 @@
 + 
 + // Use -maes to get this one
 + #elif defined(__x86_64__) && defined(__AES__)
-+     asm volatile(
++     __asm__ volatile(
 +         "movups (%0),  %%xmm0     \n"
 + 	"movups (%1),  %%xmm1     \n"
 + 	"pxor   %%xmm1,%%xmm0     \n" // add_round_key(state, key_schedule)
@@ -414,7 +414,7 @@
 + // build with -mcpu=cortex-a53+crc to enable native CRC instruction on ARM
 + static inline uint32_t rf_crc32_32(uint32_t crc, uint32_t msg) {
 + #if defined(__aarch64__) && defined(__ARM_FEATURE_CRC32)
-+   asm("crc32w %w0,%w0,%w1\n":"+r"(crc):"r"(msg));
++   __asm__("crc32w %w0,%w0,%w1\n":"+r"(crc):"r"(msg));
 + #else
 +   crc=crc^msg;
 +   crc=rf_crc32_table[crc&0xff]^(crc>>8);
@@ -427,8 +427,8 @@
 + 
 + //static inline uint32_t rf_crc32_24(uint32_t crc, uint32_t msg) {
 + //#if defined(__aarch64__) && defined(__ARM_FEATURE_CRC32)
-+ //  asm("crc32b %w0,%w0,%w1\n":"+r"(crc):"r"(msg));
-+ //  asm("crc32h %w0,%w0,%w1\n":"+r"(crc):"r"(msg>>8));
++ //  __asm__("crc32b %w0,%w0,%w1\n":"+r"(crc):"r"(msg));
++ //  __asm__("crc32h %w0,%w0,%w1\n":"+r"(crc):"r"(msg>>8));
 + //#else
 + //  crc=crc^msg;
 + //  crc=rf_crc32_table[crc&0xff]^(crc>>8);
@@ -440,7 +440,7 @@
 + //
 + //static inline uint32_t rf_crc32_16(uint32_t crc, uint32_t msg) {
 + //#if defined(__aarch64__) && defined(__ARM_FEATURE_CRC32)
-+ //  asm("crc32h %w0,%w0,%w1\n":"+r"(crc):"r"(msg));
++ //  __asm__("crc32h %w0,%w0,%w1\n":"+r"(crc):"r"(msg));
 + //#else
 + //  crc=crc^msg;
 + //  crc=rf_crc32_table[crc&0xff]^(crc>>8);
@@ -451,7 +451,7 @@
 + //
 + //static inline uint32_t rf_crc32_8(uint32_t crc, uint32_t msg) {
 + //#if defined(__aarch64__) && defined(__ARM_FEATURE_CRC32)
-+ //  asm("crc32b %w0,%w0,%w1\n":"+r"(crc):"r"(msg));
++ //  __asm__("crc32b %w0,%w0,%w1\n":"+r"(crc):"r"(msg));
 + //#else
 + //  crc=crc^msg;
 + //  crc=rf_crc32_table[crc&0xff]^(crc>>8);
@@ -464,7 +464,7 @@
 + static inline uint64_t rf_add64_crc32(uint64_t msg) {
 +   uint64_t crc=0;
 + #if defined(__aarch64__) && defined(__ARM_FEATURE_CRC32)
-+   asm("crc32x %w0,%w0,%x1\n":"+r"(crc):"r"(msg));
++   __asm__("crc32x %w0,%w0,%x1\n":"+r"(crc):"r"(msg));
 + #else
 +   crc^=(uint32_t)msg;
 +   crc=rf_crc32_table[crc&0xff]^(crc>>8);
@@ -532,9 +532,9 @@
 + // reverse all bytes in the word _v_
 + static inline uint64_t rf_bswap64(uint64_t v) {
 + #if defined(__x86_64__)
-+   asm("bswap %0":"+r"(v));
++   __asm__("bswap %0":"+r"(v));
 + #elif defined(__aarch64__)
-+   asm("rev %0,%0\n":"+r"(v));
++   __asm__("rev %0,%0\n":"+r"(v));
 + #else
 +   v=((v&0xff00ff00ff00ff00ULL)>>8)|((v&0x00ff00ff00ff00ffULL)<<8);
 +   v=((v&0xffff0000ffff0000ULL)>>16)|((v&0x0000ffff0000ffffULL)<<16);
@@ -565,7 +565,7 @@
 + #if defined(__ARM_ARCH_8A) || defined(__AARCH64EL__)
 +   // 128 bit at once is faster when exactly two parallelizable instructions are
 +   // used between two calls to keep the pipe full.
-+   asm volatile("stp %0, %1, [%2,#%3]\n\t"
++   __asm__ volatile("stp %0, %1, [%2,#%3]\n\t"
 +                : /* no output */
 +                : "r"(x), "r"(y), "r" (cell), "I" (ofs*8));
 + #else


### PR DESCRIPTION
Applied the changes suggested by @aivve in a comment to pull request #4 :

  . s/asm/__asm__/   (even in patches)
  . include io.h and windows.h instead of unistd.h on windows
  . the other one (void* => char*) should already be OK

Still builds on ubuntu, not tested on windows.