### PR TITLE
rf_test: better cmdline + threads

### DIFF
--- a/rf_test.c
+++ b/rf_test.c
@@ -7,6 +7,8 @@
 //   - on ARMv8: use gcc -march=native or -march=armv8-a+crypto+crc to enable
 //               CRC32 and AES extensions.
 
+#include <sys/time.h>
+#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -18,6 +20,79 @@
 #endif
 
 #include "rf_core.c"
+
+static volatile unsigned long hashes;
+static struct timeval tv_start;
+
+/* test message */
+const uint8_t test_msg[80] =
+	"\x01\x02\x04\x08\x10\x20\x40\x80"
+	"\x01\x03\x05\x09\x11\x21\x41\x81"
+	"\x02\x02\x06\x0A\x12\x22\x42\x82"
+	"\x05\x06\x04\x0C\x14\x24\x44\x84"
+	"\x09\x0A\x0C\x08\x18\x28\x48\x88"
+	"\x11\x12\x14\x18\x10\x30\x50\x90"
+	"\x21\x22\x24\x28\x30\x20\x60\xA0"
+	"\x41\x42\x44\x48\x50\x60\x40\xC0"
+	"\x81\x82\x84\x88\x90\xA0\xC0\x80"
+	"\x18\x24\x42\x81\x99\x66\x55\xAA";
+
+/* valid pattern for 256 rounds of the test message */
+const uint8_t test_msg_out256[32] =
+	"\xd7\x76\xc9\xda\x11\x18\xe3\xb0"
+	"\x92\x7f\x36\x8e\x55\x73\x70\xe8"
+	"\xb9\xa6\xb9\x30\xf1\x09\xc5\xf7"
+	"\x29\x1c\x5c\x5c\x46\xf1\x5a\x94";
+
+void run_bench(void *rambox)
+{
+	unsigned int loops = 0;
+	unsigned int i;
+	uint8_t msg[80];
+	uint8_t out[32];
+
+	memcpy(msg, test_msg, sizeof(msg));
+
+	while (1) {
+		/* modify the message on each loop */
+		for (i = 0; i < sizeof(msg) / sizeof(msg[0]); i++)
+			msg[i] ^= loops;
+
+		rf256_hash(out, msg, sizeof(msg), rambox, NULL);
+
+		/* the output is reinjected at the beginning of the
+		 * message, before it is modified again.
+		 */
+		memcpy(msg, out, 32);
+		loops++;
+		hashes++;
+	}
+}
+
+void report_bench(int sig)
+{
+	struct timeval tv_now;
+	unsigned long work;
+	long sec, usec;
+	double elapsed;
+
+	(void)sig;
+
+	gettimeofday(&tv_now, NULL);
+	work = hashes; hashes = 0;
+	sec = tv_now.tv_sec   - tv_start.tv_sec;
+	usec = tv_now.tv_usec - tv_start.tv_usec;
+	tv_start = tv_now;
+
+	if (usec < 0) {
+		usec += 1000000;
+		sec -= 1;
+	}
+	elapsed = (double)sec + usec / 1000000.0;
+	printf("%.3f hashes/s (%lu hashes, %.3f sec)\n",
+	       (double)work / elapsed, work, elapsed);
+	alarm(1);
+}
 
 static void print256(const uint8_t *b, const char *tag)
 {
@@ -45,8 +120,6 @@ void usage(const char *name, int ret)
 int main(int argc, char **argv)
 {
 	unsigned int loops;
-	uint32_t msg[20];
-	unsigned char md[32];
 	const char *name;
 	const char *text;
 	void *rambox;
@@ -95,11 +168,6 @@ int main(int argc, char **argv)
 	if (mode == MODE_CHECK) {
 		uint8_t msg[80];
 		uint8_t out[32];
-		uint8_t val[32] =
-			"\xd7\x76\xc9\xda\x11\x18\xe3\xb0"
-			"\x92\x7f\x36\x8e\x55\x73\x70\xe8"
-			"\xb9\xa6\xb9\x30\xf1\x09\xc5\xf7"
-			"\x29\x1c\x5c\x5c\x46\xf1\x5a\x94";
 
 		rambox = malloc(RF_RAMBOX_SIZE * 8);
 		if (rambox == NULL)
@@ -109,18 +177,7 @@ int main(int argc, char **argv)
 		/* preinitialize the message with a complex pattern that
 		 * is easy to recognize.
 		 */
-		memcpy(msg,
-		       "\x01\x02\x04\x08\x10\x20\x40\x80"
-		       "\x01\x03\x05\x09\x11\x21\x41\x81"
-		       "\x02\x02\x06\x0A\x12\x22\x42\x82"
-		       "\x05\x06\x04\x0C\x14\x24\x44\x84"
-		       "\x09\x0A\x0C\x08\x18\x28\x48\x88"
-		       "\x11\x12\x14\x18\x10\x30\x50\x90"
-		       "\x21\x22\x24\x28\x30\x20\x60\xA0"
-		       "\x41\x42\x44\x48\x50\x60\x40\xC0"
-		       "\x81\x82\x84\x88\x90\xA0\xC0\x80"
-		       "\x18\x24\x42\x81\x99\x66\x55\xAA",
-		       sizeof(msg));
+		memcpy(msg, test_msg, sizeof(msg));
 
 		for (loops = 0; loops < 256; loops++) {
 			unsigned int i;
@@ -136,31 +193,26 @@ int main(int argc, char **argv)
 			 */
 			memcpy(msg, out, 32);
 		}
-		if (memcmp(out, val, sizeof(val)) != 0) {
+		if (memcmp(out, test_msg_out256, sizeof(test_msg_out256)) != 0) {
 			print256(out, " invalid");
-			print256(val, "expected");
+			print256(test_msg_out256, "expected");
 			exit(1);
 		}
 		print256(out, "valid");
 		exit(0);
 	}
 
-	rambox = malloc(RF_RAMBOX_SIZE * 8);
-	if (rambox == NULL)
-		exit(1);
-	rf_raminit(rambox);
+	if (mode == MODE_BENCH) {
+		rambox = malloc(RF_RAMBOX_SIZE * 8);
+		if (rambox == NULL)
+			exit(1);
 
-	for (loops=0;loops<20;loops++)
-		msg[loops]=loops;
+		rf_raminit(rambox);
 
-	for (loops=0; loops<1000/*000*/; loops++) {
-		if (!(loops&0x3ffff))
-			printf("%u\n", loops);
-		msg[19] = loops;
-		rf256_hash(md, msg, sizeof(msg), rambox, NULL);
-		//memcpy(msg, md, 32);
+		signal(SIGALRM, report_bench);
+		alarm(1);
+		run_bench(rambox);
+		/* should never get here */
 	}
-	printf("%u\n", loops);
-	print256(md, "md");
 	exit(0);
 }


### PR DESCRIPTION
Hello,

this morning I modified rf_test to support command line arguments and threads. Now we have a benchmark mode (-b), a check mode (-c), a message hash mode (-m) and the number of threads (-t). I tried as much as possible to remain compatible with non-pthread systems though I don't have any.
It's more convenient than "time + &" which is not very accurate due to the time spent in malloc(), or on machines with different CPU speeds.

The results are absolutely impressive, my $35 NanoPI-Fire3 is twice as fast as my overclocked Skylake i7 and draws about 15 times less power! Here's what I could test so far : 
```
$ cat results.txt 
i7-6700k at 8*4.4 GHz (4 cores, 8 threads)
$ ./rf_test -b -t 8
1383 hashes, 1.231 sec, 8 threads, 1123.756 H/s, 140.470 H/s/thread
1394 hashes, 1.000 sec, 8 threads, 1393.947 H/s, 174.243 H/s/thread
1393 hashes, 1.000 sec, 8 threads, 1392.967 H/s, 174.121 H/s/thread
^C

i7-6700k at 4*4.4 GHz (4 cores, 4 threads)
$ ./rf_test -b -t 4
818 hashes, 1.073 sec, 4 threads, 762.599 H/s, 190.650 H/s/thread
821 hashes, 1.000 sec, 4 threads, 820.974 H/s, 205.243 H/s/thread
^C

RPi3B+ 4xA53@1.4 GHz
$ ./rf_test -b -t 4
962 hashes, 1.613 sec, 4 threads, 596.516 H/s, 149.129 H/s/thread
980 hashes, 1.002 sec, 4 threads, 978.483 H/s, 244.621 H/s/thread
979 hashes, 1.000 sec, 4 threads, 978.627 H/s, 244.657 H/s/thread
976 hashes, 1.000 sec, 4 threads, 975.542 H/s, 243.886 H/s/thread
979 hashes, 1.000 sec, 4 threads, 978.635 H/s, 244.659 H/s/thread
979 hashes, 1.000 sec, 4 threads, 978.612 H/s, 244.653 H/s/thread
977 hashes, 1.000 sec, 4 threads, 976.642 H/s, 244.160 H/s/thread
^C

NanoPI-Fire3 8xA53@1.6 GHz
$ ./rf_test-armv8 -b -t 8
2748 hashes, 2.100 sec, 8 threads, 1308.438 H/s, 163.555 H/s/thread
2839 hashes, 1.004 sec, 8 threads, 2827.867 H/s, 353.483 H/s/thread
2839 hashes, 1.004 sec, 8 threads, 2827.844 H/s, 353.481 H/s/thread
2837 hashes, 1.004 sec, 8 threads, 2825.824 H/s, 353.228 H/s/thread
2839 hashes, 1.004 sec, 8 threads, 2827.853 H/s, 353.482 H/s/thread
2840 hashes, 1.004 sec, 8 threads, 2828.851 H/s, 353.606 H/s/thread
^C

NanoPC-T3 8xA53@1.4 GHz
fa@NanoPC-T3:~$ /tmp/rf_test-armv8 -b -t 8
2362 hashes, 2.034 sec, 8 threads, 1161.333 H/s, 145.167 H/s/thread
2494 hashes, 1.004 sec, 8 threads, 2484.299 H/s, 310.537 H/s/thread
2465 hashes, 1.004 sec, 8 threads, 2455.377 H/s, 306.922 H/s/thread
2443 hashes, 1.004 sec, 8 threads, 2433.395 H/s, 304.174 H/s/thread
^C

NanoPI-M4 4xA53@1.6+2xA72@2.1 GHz
$ ./rf_test -b -t 6
1996 hashes, 1.476 sec, 6 threads, 1352.261 H/s, 225.377 H/s/thread
2003 hashes, 1.000 sec, 6 threads, 2002.744 H/s, 333.791 H/s/thread
2002 hashes, 1.000 sec, 6 threads, 2001.822 H/s, 333.637 H/s/thread
2003 hashes, 1.000 sec, 6 threads, 2002.810 H/s, 333.802 H/s/thread
^C

NanoPI-Neo4 @4xA53@1.5+2xA72@2.0 GHz :
$ ./rf_test-armv8 -b -t 6
1952 hashes, 1.836 sec, 6 threads, 1063.097 H/s, 177.183 H/s/thread
1959 hashes, 1.000 sec, 6 threads, 1958.651 H/s, 326.442 H/s/thread
1959 hashes, 1.000 sec, 6 threads, 1958.788 H/s, 326.465 H/s/thread
1959 hashes, 1.000 sec, 6 threads, 1958.824 H/s, 326.471 H/s/thread
^C

MacchiatoBin 4xA72@2.0 GHz
$ ./rf_test-armv8 -b -t 4
1150 hashes, 1.114 sec, 4 threads, 1032.007 H/s, 258.002 H/s/thread
1292 hashes, 1.000 sec, 4 threads, 1291.860 H/s, 322.965 H/s/thread
1292 hashes, 1.000 sec, 4 threads, 1291.925 H/s, 322.981 H/s/thread
1290 hashes, 1.000 sec, 4 threads, 1289.808 H/s, 322.452 H/s/thread
1291 hashes, 1.000 sec, 4 threads, 1290.815 H/s, 322.704 H/s/thread
^C

NanoPI-NeoPlus2 4xA53@1248 MHz
$ ./rf_test-armv8 -b -t 4
1074 hashes, 1.331 sec, 4 threads, 806.950 H/s, 201.738 H/s/thread
1098 hashes, 1.000 sec, 4 threads, 1097.710 H/s, 274.428 H/s/thread
1081 hashes, 1.000 sec, 4 threads, 1080.839 H/s, 270.210 H/s/thread
1077 hashes, 1.000 sec, 4 threads, 1076.835 H/s, 269.209 H/s/thread
1097 hashes, 1.000 sec, 4 threads, 1096.838 H/s, 274.209 H/s/thread
1084 hashes, 1.000 sec, 4 threads, 1083.834 H/s, 270.959 H/s/thread
^C

ROC-RK3328-CC 4xA53@1384 MHz
$ /tmp/rf_test-armv8 -b -t 4
1200 hashes, 1.270 sec, 4 threads, 945.192 H/s, 236.298 H/s/thread
1223 hashes, 1.000 sec, 4 threads, 1222.487 H/s, 305.622 H/s/thread
1223 hashes, 1.000 sec, 4 threads, 1222.601 H/s, 305.650 H/s/thread
1224 hashes, 1.000 sec, 4 threads, 1223.599 H/s, 305.900 H/s/thread
1223 hashes, 1.000 sec, 4 threads, 1222.630 H/s, 305.657 H/s/thread
^C
```
