### PR TITLE
Cleaned up print256

### DIFF
--- a/rainforest.c
+++ b/rainforest.c
@@ -603,11 +603,28 @@ void rf256_hash2(void *out, const void *in, size_t len, uint32_t seed) {
   rf256_update(&ctx, in, len);
   rf256_final(out, &ctx);
 }
-
+#define RAINFOREST_TEST 1
 #ifdef RAINFOREST_TEST
 static void print256(const uint8_t *b, const char *tag) {
+
+	uint32_t i=0x01234567;
+	uint8_t  endian = ((*((uint8_t*)(&i))) == 0x67);
 	uint64_t* b_64 = (uint64_t*)b;
-  printf("%s: %016jx%016jx.%016jx%016jx",b_64[0],b_64[1],b_64[2],b_64[3]);
+	if(endian){
+		printf("%s: %016jx%016jx.%016jx%016jx\n",tag,b_64[0],b_64[1],b_64[2],b_64[3]);
+	} else {
+		for(uint8_t j=0;j<4;j++){	
+			b_64[j]=   ((b_64[j]&0xff00000000000000ULL)>>56)
+				 | ((b_64[j]&0x00ff000000000000ULL)>>40)
+				 | ((b_64[j]&0x0000ff0000000000ULL)>>24)
+				 | ((b_64[j]&0x000000ff00000000ULL)>> 8)
+				 | ((b_64[j]&0x00000000ff000000ULL)<< 8)
+				 | ((b_64[j]&0x0000000000ff0000ULL)<<24)
+				 | ((b_64[j]&0x000000000000ff00ULL)<<40)
+				 | ((b_64[j]&0x00000000000000ffULL)<<56);
+		}	
+		printf("%s: %016jx%016jx.%016jx%016jx\n",tag,b_64[0],b_64[1],b_64[2],b_64[3]);
+	}
 }
 
 int main(int argc, char **argv) {

--- a/rainforest.c
+++ b/rainforest.c
@@ -606,13 +606,8 @@ void rf256_hash2(void *out, const void *in, size_t len, uint32_t seed) {
 
 #ifdef RAINFOREST_TEST
 static void print256(const uint8_t *b, const char *tag) {
-  printf("%s: %02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x"
-	 ".%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x\n",
-         tag,
-         b[0],  b[1],  b[2],  b[3],  b[4],  b[5],  b[6],  b[7],
-         b[8],  b[9],  b[10], b[11], b[12], b[13], b[14], b[15],
-         b[16], b[17], b[18], b[19], b[20], b[21], b[22], b[23],
-         b[24], b[25], b[26], b[27], b[28], b[29], b[30], b[31]);
+	uint64_t* b_64 = (uint64_t*)b;
+  printf("%s: %016jx%016jx.%016jx%016jx",b_64[0],b_64[1],b_64[2],b_64[3]);
 }
 
 int main(int argc, char **argv) {

--- a/rainforest.c
+++ b/rainforest.c
@@ -603,28 +603,11 @@ void rf256_hash2(void *out, const void *in, size_t len, uint32_t seed) {
   rf256_update(&ctx, in, len);
   rf256_final(out, &ctx);
 }
-#define RAINFOREST_TEST 1
 #ifdef RAINFOREST_TEST
 static void print256(const uint8_t *b, const char *tag) {
-
-	uint32_t i=0x01234567;
-	uint8_t  endian = ((*((uint8_t*)(&i))) == 0x67);
-	uint64_t* b_64 = (uint64_t*)b;
-	if(endian){
-		printf("%s: %016jx%016jx.%016jx%016jx\n",tag,b_64[0],b_64[1],b_64[2],b_64[3]);
-	} else {
-		for(uint8_t j=0;j<4;j++){	
-			b_64[j]=   ((b_64[j]&0xff00000000000000ULL)>>56)
-				 | ((b_64[j]&0x00ff000000000000ULL)>>40)
-				 | ((b_64[j]&0x0000ff0000000000ULL)>>24)
-				 | ((b_64[j]&0x000000ff00000000ULL)>> 8)
-				 | ((b_64[j]&0x00000000ff000000ULL)<< 8)
-				 | ((b_64[j]&0x0000000000ff0000ULL)<<24)
-				 | ((b_64[j]&0x000000000000ff00ULL)<<40)
-				 | ((b_64[j]&0x00000000000000ffULL)<<56);
-		}	
-		printf("%s: %016jx%016jx.%016jx%016jx\n",tag,b_64[0],b_64[1],b_64[2],b_64[3]);
-	}
+	printf("%s: ",tag);
+	for(uint8_t i=0;i<32;i++) printf("%x",b[i]);
+	printf("\n");
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
Pro: Its faster, has the same support and the same output. But requires a few lines less code and is definitely more readable.

Known trade-offs: one cast needed