### PR TITLE
fix build on gcc < 4.7 + add test for check_sin() in rf_test -c

### DIFF
--- a/rf_core.c
+++ b/rf_core.c
@@ -253,6 +253,16 @@ static inline uint64_t rf_revbit64(uint64_t v)
 	return v;
 }
 
+#if defined(__GNUC__) && (__GNUC__ < 4 || __GNUC__ == 4 && __GNUC_MINOR__ < 7) && !defined(__clang__)
+static inline unsigned long __builtin_clrsbl(int64_t x)
+{
+	if (x < 0)
+		return __builtin_clzl(~(x << 1));
+	else
+		return __builtin_clzl(x << 1);
+}
+#endif
+
 // lookup _old_ in _rambox_, update it and perform a substitution if a matching
 // value is found.
 static inline uint32_t rf_rambox(rf256_ctx_t *ctx, uint64_t old)

--- a/rf_test.c
+++ b/rf_test.c
@@ -146,7 +146,7 @@ void usage(const char *name, int ret)
 }
 
 // validate that the sin() and pow() functions work as expected
-void check_sin()
+int check_sin()
 {
 	unsigned int i;
 	unsigned int stop;
@@ -173,7 +173,9 @@ void check_sin()
 	if (sum1 != 300239689190865 || sum5 != 300239688428374) {
 		printf("sum1=%ld sum5=%ld p1=%u p5=%u d=%f\n",
 		       sum1, sum5, prev1, prev5, d);
+		return 0;
 	}
+	return 1;
 }
 
 int main(int argc, char **argv)
@@ -237,6 +239,9 @@ int main(int argc, char **argv)
 		uint8_t msg[80];
 		uint8_t out[32];
 		void *rambox;
+
+		if (!check_sin())
+			exit(1);
 
 		rambox = malloc(RF_RAMBOX_SIZE * 8);
 		if (rambox == NULL)


### PR DESCRIPTION
It took me some head scratching to figure why my atom was failing on this (I used clz instead of clzl) and I realized that it would be useful to have more error detection in rf_test so I called check_sin() as well.

The perf on my atom is now:
```
59 hashes, 1.000 sec, 2 threads, 58.995 H/s, 29.497 H/s/thread
55 hashes, 1.000 sec, 2 threads, 54.995 H/s, 27.498 H/s/thread
60 hashes, 1.000 sec, 2 threads, 59.994 H/s, 29.997 H/s/thread
58 hashes, 1.000 sec, 2 threads, 57.994 H/s, 28.997 H/s/thread
```
By the way it's not an N410 but a D510 (dual-core with HT disabled).
