### PR TITLE
update opencl code to latest changes

### DIFF
--- a/rfv2.cl
+++ b/rfv2.cl
@@ -460,16 +460,16 @@ static inline ulong rf_rotl64(ulong v, uchar bits)
 #if 1
 	return rotate(v, (ulong)bits);
 #else
-	return (v << bits) | (v >> (64 - bits));
+	return (v << bits) | (v >> (-bits & 63));
 #endif
 }
 
 static inline ulong rf_rotr64(ulong v, uchar bits)
 {
 #if 1
-	return rotate(v, (ulong)(64 - bits));
+	return rotate(v, (ulong)(-bits & 63));
 #else
-	return (v >> bits) | (v << (64 - bits));
+	return (v >> bits) | (v << (-bits & 63));
 #endif
 }
 

--- a/rfv2.cl
+++ b/rfv2.cl
@@ -314,8 +314,10 @@ static inline ulong rf_crc32_64(uint crc, ulong msg)
 
 static inline uint rf_crc32_mem(uint crc, const void *msg, size_t len)
 {
+	const uchar *msg8 = (const uchar *)msg;
+
 	while (len--) {
-		crc = rf_crc32_8(crc, *(uchar*)msg++);
+		crc = rf_crc32_8(crc, *msg8++);
 	}
 	return crc;
 }
@@ -713,16 +715,18 @@ static void rfv2_init(rfv2_ctx_t *ctx, uint seed, __global void *rambox)
 
 static void rfv2_update(rfv2_ctx_t *ctx, const void *msg, size_t len)
 {
+	const uchar *msg8 = (const uchar *)msg;
+
 	while (len > 0) {
 		if (!(ctx->len & 3) && len >= 4) {
-			ctx->word = *(uint *)msg;
+			ctx->word = *(uint *)msg8;
 			ctx->len += 4;
 			rfv2_one_round(ctx);
-			msg += 4;
+			msg8 += 4;
 			len -= 4;
 			continue;
 		}
-		ctx->word |= ((uint)*(uchar *)msg++) << (8 * (ctx->len++ & 3));
+		ctx->word |= ((uint)*msg8++) << (8 * (ctx->len++ & 3));
 		len--;
 		if (!(ctx->len & 3))
 			rfv2_one_round(ctx);

--- a/rfv2.cl
+++ b/rfv2.cl
@@ -855,11 +855,24 @@ int check_hash(__global ulong *rambox)
 		"\x81\x82\x84\x88\x90\xA0\xC0\x80"
 		"\x18\x24\x42\x81\x99\x66\x55\xAA";
 
+	const uchar test_msg_out[32] =
+		"\xc4\x22\x65\x35\x6d\xe9\x09\x39"
+		"\xda\xd4\xc1\xda\x00\xe0\xcc\x89"
+		"\xdd\x42\x72\xdc\xc6\xa5\x5e\x24"
+		"\x2a\x29\x30\xe8\xa7\xca\x52\xd2";
+
 	uchar hash[32];
+	int i;
 
 	rfv2_hash(&hash, &data, sizeof(data), rambox, 0);
 
-	printf("[%u] test data:\n"
+	for (i = 0; i < 32 && hash[i] == test_msg_out[i]; i++)
+		;
+
+	if (i == 32)
+		return 1;
+
+	printf("[%u] Invalid hash: test data:\n"
 	       "     %02x %02x %02x %02x %02x %02x %02x %02x\n"
 	       "     %02x %02x %02x %02x %02x %02x %02x %02x\n"
 	       "     %02x %02x %02x %02x %02x %02x %02x %02x\n"
@@ -890,6 +903,7 @@ int check_hash(__global ulong *rambox)
 	       hash[0x08], hash[0x09], hash[0x0a], hash[0x0b], hash[0x0c], hash[0x0d], hash[0x0e], hash[0x0f],
 	       hash[0x10], hash[0x11], hash[0x12], hash[0x13], hash[0x14], hash[0x15], hash[0x16], hash[0x17],
 	       hash[0x18], hash[0x19], hash[0x1a], hash[0x1b], hash[0x1c], hash[0x1d], hash[0x1e], hash[0x1f]);
+	return 0;
 }
 
 ////////////////////////// equivalent of rfv2_cpuminer.c ////////////////////////
@@ -912,9 +926,9 @@ __kernel void search(__global const ulong *input, __global uint *output, __globa
 	// the rambox must be initialized by the first call for each thread
 	if (gid < MAX_GLOBAL_THREADS) {
 		// printf("init glob %u lt %u maxglob=%u\n", gid, get_local_id(0), MAX_GLOBAL_THREADS);
-		//check_sin();
+		check_sin();
 		rfv2_raminit(rambox);
-		//check_hash(rambox);
+		check_hash(rambox);
 	}
 
 	((uint16 *)data)[0] = ((__global const uint16 *)input)[0];

--- a/rfv2_core.c
+++ b/rfv2_core.c
@@ -203,19 +203,29 @@ static inline uint64_t rf_whtable(uint8_t index)
 // rotate left vector _v_ by _bits_ bits
 static inline uint64_t rf_rotl64(uint64_t v, uint8_t bits)
 {
-#if !defined(__ARM_ARCH_8A) && !defined(__AARCH64EL__) && !defined(x86_64)
+#if !defined(RF_NOASM) && defined(__x86_64__)
+	__asm__("rol %1, %0" : "+r"(v) : "c"(bits));
+#else
+#if !defined(__ARM_ARCH_8A) && !defined(__x86_64__)
 	bits &= 63;
 #endif
-	return (v << bits) | (v >> (64 - bits));
+	v = (v << bits) | (v >> (-bits & 63));
+#endif
+	return v;
 }
 
 // rotate right vector _v_ by _bits_ bits
 static inline uint64_t rf_rotr64(uint64_t v, uint8_t bits)
 {
-#if !defined(__ARM_ARCH_8A) && !defined(__AARCH64EL__) && !defined(x86_64)
+#if !defined(RF_NOASM) && defined(__x86_64__)
+	__asm__("ror %1, %0" : "+r"(v) : "c"(bits));
+#else
+#if !defined(__ARM_ARCH_8A) && !defined(__x86_64__)
 	bits &= 63;
 #endif
-	return (v >> bits) | (v << (64 - bits));
+	v = (v >> bits) | (v << (-bits & 63));
+#endif
+	return v;
 }
 
 // reverse all bytes in the word _v_

--- a/rfv2_core.c
+++ b/rfv2_core.c
@@ -201,10 +201,10 @@ static inline uint64_t rf_whtable(uint8_t index)
 }
 
 // rotate left vector _v_ by _bits_ bits
-static inline uint64_t rf_rotl64(uint64_t v, uint8_t bits)
+static inline uint64_t rf_rotl64(uint64_t v, uint64_t bits)
 {
 #if !defined(RF_NOASM) && defined(__x86_64__)
-	__asm__("rol %1, %0" : "+r"(v) : "c"(bits));
+	__asm__("rol %1, %0" : "+r"(v) : "c"((uint8_t)bits));
 #else
 #if !defined(__ARM_ARCH_8A) && !defined(__x86_64__)
 	bits &= 63;
@@ -215,10 +215,10 @@ static inline uint64_t rf_rotl64(uint64_t v, uint8_t bits)
 }
 
 // rotate right vector _v_ by _bits_ bits
-static inline uint64_t rf_rotr64(uint64_t v, uint8_t bits)
+static inline uint64_t rf_rotr64(uint64_t v, uint64_t bits)
 {
 #if !defined(RF_NOASM) && defined(__x86_64__)
-	__asm__("ror %1, %0" : "+r"(v) : "c"(bits));
+	__asm__("ror %1, %0" : "+r"(v) : "c"((uint8_t)bits));
 #else
 #if !defined(__ARM_ARCH_8A) && !defined(__x86_64__)
 	bits &= 63;

--- a/rfv2_core.c
+++ b/rfv2_core.c
@@ -279,7 +279,7 @@ static inline void rf_w128(uint64_t *cell, size_t ofs, uint64_t x, uint64_t y)
 #if !defined(RF_NOASM) && (defined(__ARM_ARCH_8A) || defined(__AARCH64EL__))
 	// 128 bit at once is faster when exactly two parallelizable instructions are
 	// used between two calls to keep the pipe full.
-	__asm__ volatile("stp %0, %1, [%2,#%3]\n\t"
+	__asm__ volatile("stp %0, %1, [%2,%3]\n\t"
 			 : /* no output */
 			 : "r"(x), "r"(y), "r" (cell), "I" (ofs * 8));
 #else

--- a/rfv2_test.c
+++ b/rfv2_test.c
@@ -144,7 +144,7 @@ void usage(const char *name, int ret)
 // validate that the sin() and pow() functions work as expected
 int check_sin()
 {
-	unsigned int i;
+	volatile unsigned int i;
 	unsigned int stop;
 	double d;
 	unsigned long sum1, sum5;


### PR DESCRIPTION
I wanted to try the GPU in my intel CPU using the opencl code but noticed that 1) it had not been updated since last changes, and 2) there were a few issues there. In the end it produces bad hashes.
Apparently this GPU doesn't support true 64-bit FP from what I'm reading on the net, it's emulated in software (https://freedesktop.org/wiki/Software/Beignet/). And according to https://docs.nvidia.com/cuda/floating-point/index.html it seems pretty common for implementations to drop some precision there. So no luck for me. I tried on my Odroid-MC1 but sgminer segfaults there. At least I've fixed the few build issues that were reported there.
