### PR TITLE
Fix some non-c99 build issues

### DIFF
--- a/rfv2_core.c
+++ b/rfv2_core.c
@@ -232,7 +232,7 @@ static inline uint64_t rf_rotr64(uint64_t v, uint64_t bits)
 static inline uint64_t rf_bswap64(uint64_t v)
 {
 #if !defined(RF_NOASM) && defined(__x86_64__) && !defined(_MSC_VER)
-	__asm__("bswap %0":"+r"(v));
+	__asm__("bswapq %0":"+r"(v));
 #elif !defined(RF_NOASM) && defined(__aarch64__)
 	__asm__("rev %0,%0\n":"+r"(v));
 #else
@@ -253,7 +253,7 @@ static inline uint64_t rf_revbit64(uint64_t v)
 	v = ((v & 0xccccccccccccccccULL) >> 2) | ((v & 0x3333333333333333ULL) << 2);
 	v = ((v & 0xf0f0f0f0f0f0f0f0ULL) >> 4) | ((v & 0x0f0f0f0f0f0f0f0fULL) << 4);
 #if !defined(RF_NOASM) && defined(__x86_64__)
-	__asm__("bswap %0" : "=r"(v) : "0"(v));
+	__asm__("bswapq %0" : "=r"(v) : "0"(v));
 #else
 	v = ((v & 0xff00ff00ff00ff00ULL) >> 8)  | ((v & 0x00ff00ff00ff00ffULL) << 8);
 	v = ((v & 0xffff0000ffff0000ULL) >> 16) | ((v & 0x0000ffff0000ffffULL) << 16);

--- a/rfv2_core.c
+++ b/rfv2_core.c
@@ -249,9 +249,9 @@ static inline uint64_t rf_revbit64(uint64_t v)
 #if !defined(RF_NOASM) && defined(__aarch64__)
 	__asm__ volatile("rbit %0, %1\n" : "=r"(v) : "r"(v));
 #else
-	v = ((v & 0xaaaaaaaaaaaaaaaa) >> 1) | ((v & 0x5555555555555555) << 1);
-	v = ((v & 0xcccccccccccccccc) >> 2) | ((v & 0x3333333333333333) << 2);
-	v = ((v & 0xf0f0f0f0f0f0f0f0) >> 4) | ((v & 0x0f0f0f0f0f0f0f0f) << 4);
+	v = ((v & 0xaaaaaaaaaaaaaaaaULL) >> 1) | ((v & 0x5555555555555555ULL) << 1);
+	v = ((v & 0xccccccccccccccccULL) >> 2) | ((v & 0x3333333333333333ULL) << 2);
+	v = ((v & 0xf0f0f0f0f0f0f0f0ULL) >> 4) | ((v & 0x0f0f0f0f0f0f0f0fULL) << 4);
 #if !defined(RF_NOASM) && defined(__x86_64__)
 	__asm__("bswap %0" : "=r"(v) : "0"(v));
 #else

--- a/rfv2_test.c
+++ b/rfv2_test.c
@@ -124,8 +124,11 @@ void report_bench(int sig)
 
 static void print256(const uint8_t *b, const char *tag)
 {
+	uint8_t i;
+
 	printf("%s: ",tag);
-	for(uint8_t i=0;i<32;i++) printf("%02x",b[i]);
+	for (i = 0; i < 32;i++)
+		printf("%02x",b[i]);
 	printf("\n");
 }
 

--- a/rfv2_test.c
+++ b/rfv2_test.c
@@ -170,7 +170,7 @@ int check_sin()
 		i++;
 	} while (i != stop);
 
-	if (sum1 != 300239689190865 || sum5 != 300239688428374) {
+	if (sum1 != 300239689190865ULL || sum5 != 300239688428374ULL) {
 		printf("sum1=%ld sum5=%ld p1=%u p5=%u d=%f\n",
 		       sum1, sum5, prev1, prev5, d);
 		return 0;

--- a/rfv2_test.c
+++ b/rfv2_test.c
@@ -171,8 +171,8 @@ int check_sin()
 	} while (i != stop);
 
 	if (sum1 != 300239689190865ULL || sum5 != 300239688428374ULL) {
-		printf("sum1=%ld sum5=%ld p1=%u p5=%u d=%f\n",
-		       sum1, sum5, prev1, prev5, d);
+		printf("sum1=%lld sum5=%lld p1=%u p5=%u d=%f\n",
+		       (unsigned long long)sum1, (unsigned long long)sum5, prev1, prev5, d);
 		return 0;
 	}
 	return 1;


### PR DESCRIPTION
Just a minor error in print256() and warnings about large constants in 32-bit environments. Not sure if they can cause invalid hashes or not, but let's stay safe.
