### PR TITLE
Fix for implicit declaration of function ‘abs’ warning message

### DIFF
--- a/rfv2_core.c
+++ b/rfv2_core.c
@@ -29,6 +29,7 @@
 
 #include <stdint.h>
 #include <string.h>
+#include <stdlib.h>
 #include "rfv2.h"
 
 // these archs are fine with unaligned reads


### PR DESCRIPTION
Nothing special, just minor fix.