### PR TITLE
rfv2_test: take the start time after initializing rambox

### DIFF
--- a/rfv2_test.c
+++ b/rfv2_test.c
@@ -258,8 +258,6 @@ int main(int argc, char **argv)
 		void *rambox[MAXTHREADS] = { NULL, };
 		unsigned int thr;
 
-		gettimeofday(&tv_start, NULL);
-
 		for (thr = 0; thr < threads; thr++) {
 			rambox[thr] = malloc(RFV2_RAMBOX_SIZE * 8);
 			if (rambox[thr] == NULL) {
@@ -269,6 +267,8 @@ int main(int argc, char **argv)
 
 			rfv2_raminit(rambox[thr]);
 		}
+
+		gettimeofday(&tv_start, NULL);
 
 		signal(SIGALRM, report_bench);
 		alarm(1);


### PR DESCRIPTION
When running in benchmark mode with many threads, rfv2_test shows a
low initial hash rate due to a high initial time because the start
time covers the rambox allocation and initialization. Let's move the
first call to gettimeofday() after the rambox initialization to avoid
this.