### PR TITLE
fix occasional invalid share in cpuminer patch

### DIFF
--- a/rfv2_cpuminer.c
+++ b/rfv2_cpuminer.c
@@ -76,15 +76,15 @@ int scanhash_rfv2(int thr_id, struct work *work, uint32_t max_nonce, uint64_t *h
 		if (!ret)
 			break;
 
-		if (fulltest(hash, ptarget)) {
+		// drop invalid shares caused by rambox collisions
+		rfv2_hash(hash, (char *)endiandata, 80, rambox, NULL);
+
+		if (rf_le32toh((uint8_t*)(hash+7)) <= Htarg && fulltest(hash, ptarget)) {
 			work_set_target_ratio(work, hash);
 			pdata[19] = nonce;
 			*hashes_done = pdata[19] - first_nonce;
 			goto out;
 		}
-		else
-			printf("Warning: rfv2_scan_hdr() returned invalid solution %u\n", nonce);
-
 		nonce++;
 	} while (nonce < max_nonce && !(*restart));
 


### PR DESCRIPTION
hello Mr Schneider! This is my first pull request for rainforest. I hope it is correct. I have saw invalid share on my Raspberry Pi 3B+ and I understand it is caused by the collisions in rambox. The test in the cpuminer fonction is not enought. It is must to try to hash again with the non-optimised fucntion to be really 100% sure.
