### PR TITLE
20190526 rfv2 fix hashrate

### DIFF
--- a/patches/cpuminer-multi-39fff.diff
+++ b/patches/cpuminer-multi-39fff.diff
@@ -931,7 +931,7 @@ index 914ea77..0000000
 -	return 0;
 -}
 diff --git a/cpu-miner.c b/cpu-miner.c
-index 018d5ec..9c380a9 100644
+index 018d5ec..711565a 100644
 --- a/cpu-miner.c
 +++ b/cpu-miner.c
 @@ -112,7 +112,7 @@ enum algos {
@@ -961,7 +961,17 @@ index 018d5ec..9c380a9 100644
                            scrypt       scrypt(1024, 1, 1) (default)\n\
                            scrypt:N     scrypt(N, 1, 1)\n\
                            scrypt-jane:N (with N factor from 4 to 30)\n\
-@@ -2361,8 +2361,8 @@ static void *miner_thread(void *userdata)
+@@ -2167,6 +2167,9 @@ static void *miner_thread(void *userdata)
+ 
+ 		max64 *= (int64_t) thr_hashrates[thr_id];
+ 
++		if (opt_algo == ALGO_RFV2)
++			max64 *= 256; // optimized scan skips 255/256 nonces
++
+ 		if (max64 <= 0) {
+ 			switch (opt_algo) {
+ 			case ALGO_SCRYPT:
+@@ -2361,8 +2364,8 @@ static void *miner_thread(void *userdata)
  		case ALGO_QUBIT:
  			rc = scanhash_qubit(thr_id, &work, max_nonce, &hashes_done);
  			break;
@@ -973,7 +983,7 @@ index 018d5ec..9c380a9 100644
  		case ALGO_SCRYPT:
  			rc = scanhash_scrypt(thr_id, &work, max_nonce, &hashes_done, scratchbuf, opt_scrypt_n);
 diff --git a/cpuminer.vcxproj b/cpuminer.vcxproj
-index a881b2a..e58373b 100644
+index a881b2a..afa3b8d 100644
 --- a/cpuminer.vcxproj
 +++ b/cpuminer.vcxproj
 @@ -236,7 +236,7 @@ ﻿<?xml version="1.0" encoding="utf-8"?>
@@ -986,7 +996,7 @@ index a881b2a..e58373b 100644
      <ClCompile Include="algo\sha2.c" />
      <ClCompile Include="algo\sia.c" />
 diff --git a/cpuminer.vcxproj.filters b/cpuminer.vcxproj.filters
-index 43ec141..cf28fd5 100644
+index 43ec141..d046388 100644
 --- a/cpuminer.vcxproj.filters
 +++ b/cpuminer.vcxproj.filters
 @@ -270,7 +270,7 @@ ﻿<?xml version="1.0" encoding="utf-8"?>

--- a/rfv2_core.c
+++ b/rfv2_core.c
@@ -664,15 +664,15 @@ static inline void rfv2_update(rfv2_ctx_t *ctx, const void *msg, size_t len)
 	}
 }
 
-// pad to the next 256-bit (32 bytes) boundary
-static inline void rfv2_pad256(rfv2_ctx_t *ctx)
+// pad to the next 128-bit (16 bytes) boundary
+static inline void rfv2_pad128(rfv2_ctx_t *ctx)
 {
-	const uint8_t pad256[32] = { 0, };
+	const uint8_t pad128[16] = { 0, };
 	uint32_t pad;
 
-	pad = (32 - ctx->len) & 0xF;
+	pad = (16 - ctx->len) & 0xF;
 	if (pad)
-		rfv2_update(ctx, pad256, pad);
+		rfv2_update(ctx, pad128, pad);
 }
 
 // finalize the hash and copy the result into _out_ if not null (256 bits)
@@ -749,7 +749,7 @@ int rfv2_hash2(void *out, const void *in, size_t len, void *rambox, const void *
 	for (loop = 0; loop < loops; loop++) {
 		rfv2_update(&ctx, in, len);
 		// pad to the next 256 bit boundary
-		rfv2_pad256(&ctx);
+		rfv2_pad128(&ctx);
 	}
 
 	rfv2_final(out, &ctx);
@@ -815,11 +815,11 @@ int rfv2_scan_hdr(char *msg, void *rambox, uint32_t *hash, uint32_t target, uint
 
 		/* first loop */
 		rfv2_update(&ctx, msg, 80);
-		rfv2_pad256(&ctx);
+		rfv2_pad128(&ctx);
 
 		/* second loop */
 		rfv2_update(&ctx, msg, 80);
-		rfv2_pad256(&ctx);
+		rfv2_pad128(&ctx);
 
 		/* final */
 		rfv2_final(hash, &ctx);

--- a/rfv2_cpuminer.c
+++ b/rfv2_cpuminer.c
@@ -76,9 +76,6 @@ int scanhash_rfv2(int thr_id, struct work *work, uint32_t max_nonce, uint64_t *h
 		if (!ret)
 			break;
 
-		// drop invalid shares caused by rambox collisions
-		rfv2_hash(hash, (char *)endiandata, 80, rambox, NULL);
-
 		if (rf_le32toh((uint8_t*)(hash+7)) <= Htarg && fulltest(hash, ptarget)) {
 			work_set_target_ratio(work, hash);
 			pdata[19] = nonce;

--- a/rfv2_cpuminer.c
+++ b/rfv2_cpuminer.c
@@ -73,20 +73,23 @@ int scanhash_rfv2(int thr_id, struct work *work, uint32_t max_nonce, uint64_t *h
 	do {
 		ret = rfv2_scan_hdr((char *)endiandata, rambox, hash, Htarg, nonce, max_nonce, restart);
 		nonce = be32toh(endiandata[19]);
-		if (!ret)
+		if (ret <= 0)
 			break;
 
-		if (rf_le32toh((uint8_t*)(hash+7)) <= Htarg && fulltest(hash, ptarget)) {
+		if (fulltest(hash, ptarget)) {
 			work_set_target_ratio(work, hash);
 			pdata[19] = nonce;
-			*hashes_done = pdata[19] - first_nonce;
+			*hashes_done = ret;
+			ret = 1;
 			goto out;
 		}
 		nonce++;
 	} while (nonce < max_nonce && !(*restart));
 
+	/* not found */
 	pdata[19] = nonce;
-	*hashes_done = pdata[19] - first_nonce + 1;
+	*hashes_done = -ret;
+	ret = 0;
 out:
 	return ret;
 }


### PR DESCRIPTION
These are the pending cleanups I'm having here to report the correct hash rate and to make sure rfv2_test isn't off anymore. Now this last one does the same as the scan function and is much more accurate. cpuminer has the correct hash rate with the number of real hashes done reported, and its reporting speed was adjusted to save it from printings stats hundreds of times per second.